### PR TITLE
Bugfix/circular dependency department instructor

### DIFF
--- a/src/Database/Migrations/20250805145527-add-fk-department-to-instructors.js
+++ b/src/Database/Migrations/20250805145527-add-fk-department-to-instructors.js
@@ -1,0 +1,35 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    /**
+     * Add altering commands here.
+     *
+     * Example:
+     * await queryInterface.createTable('users', { id: Sequelize.INTEGER });
+     */
+
+    await queryInterface.addConstraint('Instructors', {
+      fields: ['department'],
+      type: 'foreign key',
+      name: 'fk_instructors_department_id', // custom constraint name
+      references: {
+        table: 'Departments',
+        field: 'department_id'
+      },
+      onUpdate: 'SET NULL',
+      onDelete: 'RESTRICT' // can change to CASCADE or RESTRICT
+    });
+  },
+
+  async down (queryInterface, Sequelize) {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+     await queryInterface.removeConstraint('Instructors', 'fk_instructors_department_id');
+  }
+};

--- a/src/Database/Migrations/20250806132734-add-fk-department-head.js
+++ b/src/Database/Migrations/20250806132734-add-fk-department-head.js
@@ -1,0 +1,34 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    /**
+     * Add altering commands here.
+     *
+     * Example:
+     * await queryInterface.createTable('users', { id: Sequelize.INTEGER });
+     */
+    await queryInterface.addConstraint('Departments', {
+      fields: ['head_id'],
+      type: 'foreign key',
+      name: 'fk_head_department_id', // custom constraint name
+      references: {
+        table: 'Instructors',
+        field: 'id'
+      },
+      onUpdate: 'SET NULL',
+      onDelete: 'RESTRICT' // can change to CASCADE or RESTRICT
+    });
+  },
+
+  async down (queryInterface, Sequelize) {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+     await queryInterface.removeConstraint('Instructors', 'fk_head_department_id');
+  }
+};

--- a/src/Database/Migrations/20250807123944-create-department-instructor.js
+++ b/src/Database/Migrations/20250807123944-create-department-instructor.js
@@ -1,0 +1,60 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.createTable('DepartmentInstructors', {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+        allowNull: false
+      },
+      instructor_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'Instructors', // Ensure this matches your actual instructors table name
+          key: 'id'
+        },
+        onDelete: 'CASCADE'
+      },
+      department_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'Departments', // Ensure this matches your actual departments table name
+          key: 'department_id'  // Or 'id' if that's the PK in Departments
+        },
+        onDelete: 'CASCADE'
+      },
+      is_active: {
+        type: Sequelize.BOOLEAN,
+        defaultValue: true
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+      },
+      created_by: {
+       type: Sequelize.INTEGER,
+       allowNull: true, // Or false if required
+      references: {
+        model: 'Users', // Table name (case-sensitive depending on DB)
+        key: 'id'
+      },
+      onDelete: 'SET NULL' // or 'CASCADE' depending on your logic
+      }
+    });
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.dropTable('DepartmentInstructors');
+  }
+};

--- a/src/Database/Migrations/20250807134826-remove-department-id-from-instructors.js
+++ b/src/Database/Migrations/20250807134826-remove-department-id-from-instructors.js
@@ -1,0 +1,33 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    /**
+     * Add altering commands here.
+     *
+     * Example:
+     * await queryInterface.createTable('users', { id: Sequelize.INTEGER });
+     */
+
+ 'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('instructors', 'department_id');
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.addColumn('instructors', 'department_id', {
+      type: Sequelize.INTEGER,
+      references: {
+        model: 'departments',
+        key: 'id'
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'SET NULL'
+    });
+  }
+}
+}
+}

--- a/src/Database/seeders/20250805140906-demo-departments.js
+++ b/src/Database/seeders/20250805140906-demo-departments.js
@@ -6,7 +6,7 @@ module.exports = {
       {
         department_name: 'Computer Science',
         department_code: 'CS101',
-        head_id: 1,
+        head_id: null,
         email: 'cs@university.edu',
         phone_number: '123-456-7890',
         building: 'Block A',
@@ -14,7 +14,7 @@ module.exports = {
       {
         department_name: 'Electrical Engineering',
         department_code: 'EE202',
-        head_id: 2,
+        head_id: null,
         email: 'ee@university.edu',
         phone_number: '987-654-3210',
         building: 'Block B',
@@ -22,7 +22,7 @@ module.exports = {
       {
         department_name: 'Mechanical Engineering',
         department_code: 'ME303',
-        head_id: 3,
+        head_id: null,
         email: 'me@university.edu',
         phone_number: '456-789-0123',
         building: 'Block C',

--- a/src/Database/seeders/20250805140906-demo-departments.js
+++ b/src/Database/seeders/20250805140906-demo-departments.js
@@ -1,0 +1,37 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.bulkInsert('Departments', [
+      {
+        department_name: 'Computer Science',
+        department_code: 'CS101',
+        head_id: 1,
+        email: 'cs@university.edu',
+        phone_number: '123-456-7890',
+        building: 'Block A',
+      },
+      {
+        department_name: 'Electrical Engineering',
+        department_code: 'EE202',
+        head_id: 2,
+        email: 'ee@university.edu',
+        phone_number: '987-654-3210',
+        building: 'Block B',
+      },
+      {
+        department_name: 'Mechanical Engineering',
+        department_code: 'ME303',
+        head_id: 3,
+        email: 'me@university.edu',
+        phone_number: '456-789-0123',
+        building: 'Block C',
+      }
+    ], {
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.bulkDelete('Departments', null, {});
+  }
+};

--- a/src/Database/seeders/20250805140906-demo-departments.js
+++ b/src/Database/seeders/20250805140906-demo-departments.js
@@ -1,9 +1,11 @@
 'use strict';
+const department = require("../../api/Models/department");
 
 module.exports = {
   async up(queryInterface, Sequelize) {
     await queryInterface.bulkInsert('Departments', [
       {
+        department_id:1,
         department_name: 'Computer Science',
         department_code: 'CS101',
         head_id: null,
@@ -12,6 +14,7 @@ module.exports = {
         building: 'Block A',
       },
       {
+        department_id:2,
         department_name: 'Electrical Engineering',
         department_code: 'EE202',
         head_id: null,
@@ -20,6 +23,7 @@ module.exports = {
         building: 'Block B',
       },
       {
+        department_id:3,
         department_name: 'Mechanical Engineering',
         department_code: 'ME303',
         head_id: null,

--- a/src/Database/seeders/20250806125124-demo-instructors.js
+++ b/src/Database/seeders/20250806125124-demo-instructors.js
@@ -5,6 +5,7 @@ module.exports = {
   async up(queryInterface, Sequelize) {
     await queryInterface.bulkInsert('Instructors', [
       {
+        id:1,
         first_name: 'Agaesh',
         last_name: 'Kumar',
         email: 'agaesh.kumar@example.com',
@@ -14,6 +15,7 @@ module.exports = {
         is_active: true
       },
       {
+        id:2,
         first_name: 'Nisha',
         last_name: 'Ravi',
         email: 'nisha.ravi@example.com',
@@ -23,6 +25,7 @@ module.exports = {
         is_active: true
       },
       {
+        id:3,
         first_name: 'Arun',
         last_name: 'Raj',
         email: 'arun.raj@example.com',

--- a/src/Database/seeders/20250806125124-demo-instructors.js
+++ b/src/Database/seeders/20250806125124-demo-instructors.js
@@ -10,7 +10,7 @@ module.exports = {
         email: 'agaesh.kumar@example.com',
         phone_number: '0123456789',
         hire_date: new Date('2023-01-10'),
-        department: 20, // Replace with actual existing department_id
+        department: null, // Replace with actual existing department_id
         is_active: true
       },
       {
@@ -19,7 +19,7 @@ module.exports = {
         email: 'nisha.ravi@example.com',
         phone_number: '0198765432',
         hire_date: new Date('2022-07-25'),
-        department: 21,
+        department: null,
         is_active: true
       },
       {
@@ -28,7 +28,7 @@ module.exports = {
         email: 'arun.raj@example.com',
         phone_number: '0172345678',
         hire_date: new Date('2021-09-15'),
-        department: 22,
+        department: null,
         is_active: false
       }
     ], {});

--- a/src/Database/seeders/20250806125124-demo-instructors.js
+++ b/src/Database/seeders/20250806125124-demo-instructors.js
@@ -1,0 +1,40 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.bulkInsert('Instructors', [
+      {
+        first_name: 'Agaesh',
+        last_name: 'Kumar',
+        email: 'agaesh.kumar@example.com',
+        phone_number: '0123456789',
+        hire_date: new Date('2023-01-10'),
+        department: 20, // Replace with actual existing department_id
+        is_active: true
+      },
+      {
+        first_name: 'Nisha',
+        last_name: 'Ravi',
+        email: 'nisha.ravi@example.com',
+        phone_number: '0198765432',
+        hire_date: new Date('2022-07-25'),
+        department: 21,
+        is_active: true
+      },
+      {
+        first_name: 'Arun',
+        last_name: 'Raj',
+        email: 'arun.raj@example.com',
+        phone_number: '0172345678',
+        hire_date: new Date('2021-09-15'),
+        department: 22,
+        is_active: false
+      }
+    ], {});
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.bulkDelete('Instructors', null, {});
+  }
+};

--- a/src/Database/seeders/20250807130913-demo-department-instructors.js
+++ b/src/Database/seeders/20250807130913-demo-department-instructors.js
@@ -1,0 +1,33 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.bulkInsert('DepartmentInstructors', [
+      {
+        id:1,
+        instructor_id: 1,
+        department_id: 1,
+        created_by: 1, // Optional, if you use this field
+        is_active: true,
+      },
+      {
+        id:2,
+        instructor_id: 2,
+        department_id: 1,
+        created_by: 1,
+        is_active: true,
+      },
+      {
+        id:3,
+        instructor_id: 3,
+        department_id: 2,
+        created_by: 2,
+        is_active: true,
+      }
+    ]);
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.bulkDelete('DepartmentInstructors', null, {});
+  }
+};

--- a/src/api/Models/department.js
+++ b/src/api/Models/department.js
@@ -4,7 +4,11 @@ const { Model } = require('sequelize');
 module.exports = (sequelize, DataTypes) => {
   class Department extends Model {
     static associate(models) {
-      // Associate with Instructor
+      // 2. One department optionally has one department head (an instructor)
+      Department.belongsTo(models.Instructor, {
+        foreignKey: 'head_id',
+        as: 'head' // This lets you do department.getHead()
+      });
     }
   }
 

--- a/src/api/Models/instructor.js
+++ b/src/api/Models/instructor.js
@@ -12,6 +12,10 @@ module.exports = (sequelize, DataTypes) => {
      */
     static associate(models) {
       // define association here
+      Instructor.belongsTo(models.Department, {
+      foreignKey: 'department_id',
+      as: 'department'
+      });
     }
   }
   Instructor.init({


### PR DESCRIPTION
### 🛠 Pull Request Summary

This PR addresses the restructuring of the **Instructor–Department** relationship due to circular dependency issues arising from previous foreign key constraints.

### ✅ Key Changes

1. **Removed `department_id`** from the `Instructor` table to eliminate the circular dependency.
2. **Created a `department_instructor` join table** to handle the **many-to-many** relationship between departments and instructors.
3. **Updated Models:**

   * Handled associations in the `Instructor` and `Department` models using `belongsToMany()`.
4. **Seeders:**

   * Added seeders for `departments`, `instructors`, and `department_instructors`.
   * Included manual `id` assignments to maintain FK integrity during `department_instructor` seeding.

### 📌 Notes

* The circular dependency was caused by `department.head_id` (FK to `Instructor`) and `instructor.department_id` (FK to `Department`) existing simultaneously.
* Moving to a many-to-many design with a join table allows more flexibility (e.g., one instructor can belong to multiple departments) and avoids cyclic FK constraints.
* Hardcoded IDs were temporarily used in the seeders for proper FK mapping; to be improved later via dynamic linking or UUIDs if required.